### PR TITLE
docs: fix path in gcr for image download

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ docker login -u _json_key -p "$(cat dockerpassword | base64 --decode)" https://u
 
 # Push, tag and pull ZenHub images into your registry
 your_registry=<your_own_registry_without_trailing_slash>
-tag=enterprise-3.0.0
-images="kraken-webapp toad-backend raptor-backend"
+tag=enterprise-2.44
+images="kraken-webapp toad-backend raptor-backend sanitycheck kraken-extension"
 for i in $(echo $images); do docker pull us.gcr.io/zenhub-public/${i}:${tag} && docker tag us.gcr.io/zenhub-public/${i}:master ${your_registry}/${i}:${tag} && docker push ${your_registry}/${i}:${tag}; done
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ docker login -u _json_key -p "$(cat dockerpassword | base64 --decode)" https://u
 your_registry=<your_own_registry_without_trailing_slash>
 tag=enterprise-3.0.0
 images="kraken-webapp toad-backend raptor-backend"
-for i in $(echo $images); do docker pull us.gcr.io/zenhub-ops/${i}:${tag} && docker tag us.gcr.io/zenhub-public/${i}:master ${your_registry}/${i}:${tag} && docker push ${your_registry}/${i}:${tag}; done
-```  
+for i in $(echo $images); do docker pull us.gcr.io/zenhub-public/${i}:${tag} && docker tag us.gcr.io/zenhub-public/${i}:master ${your_registry}/${i}:${tag} && docker push ${your_registry}/${i}:${tag}; done
+```
 
 ### 5.2 Resource Scaling
 


### PR DESCRIPTION
## changes

- Utilize `us.gcr.io/zenhub-public` for downloading images since `us.gcr.io/zenhub-ops` does not appear to work properly.
- Utilize tag of `enterprise-2.44`
- Add `sanitycheck` and `kraken-extension` images