### PR TITLE
Don't skip final snapshot

### DIFF
--- a/terraform-aws-zhe-backend/documentdb.tf
+++ b/terraform-aws-zhe-backend/documentdb.tf
@@ -13,7 +13,7 @@ resource "aws_docdb_cluster" "zhe" {
   master_username                 = var.documentdb_user
   master_password                 = random_password.documentdb_pass[count.index].result
   backup_retention_period         = 5
-  skip_final_snapshot             = false 
+  skip_final_snapshot             = false
   storage_encrypted               = true
   port                            = var.documentdb_port
   db_subnet_group_name            = aws_docdb_subnet_group.zhe[count.index].name

--- a/terraform-aws-zhe-backend/rds.tf
+++ b/terraform-aws-zhe-backend/rds.tf
@@ -22,7 +22,7 @@ resource "aws_db_instance" "zhe_postgresql" {
   db_subnet_group_name   = aws_db_subnet_group.zhe[count.index].name
   copy_tags_to_snapshot  = true
   vpc_security_group_ids = [aws_security_group.zhe_vpc.id]
-  skip_final_snapshot    = false 
+  skip_final_snapshot    = false
   tags = {
     Creator     = var.creator
     Environment = var.env


### PR DESCRIPTION
Don't skip the final snapshot in DocumentDB or RDS.

This will prevent users from unrecoverable destroying their data if they've used our terraform to deploy ZHE.