### PR TITLE
Updating demo ingress kustomize

### DIFF
--- a/k8s-cluster/options/ingress/kustomization.yaml
+++ b/k8s-cluster/options/ingress/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ingress.yaml
   - ingress-websocket.yaml
+  - ingress-cable.yaml


### PR DESCRIPTION
Missed including the raptor-cable ingress definition via kustomize with the release of ZHE 3.4.