### PR TITLE
4.3.0 release

### DIFF
--- a/k8s-cluster/README.md
+++ b/k8s-cluster/README.md
@@ -100,7 +100,7 @@ You will need to [set up an OAuth App](https://docs.github.com/en/developers/app
 
 To get started with Zenhub, you must have an existing Kubernetes cluster set up. You should:
 
-- Be using Kubernetes (>= 1.27).
+- Be using Kubernetes (>= 1.28).
 - Have `kubectl` installed locally with credentials to access the cluster.
 - Have [`kustomize`](https://kustomize.io/) installed locally (>= 4.5.7).
 - Create a dedicated Kubernetes namespace. Grant your user full access to that namespace.
@@ -143,7 +143,7 @@ Resources required:
 - IAM user `access_key_secret`
 - Bucket policy or permissions allowing bucket `list` and objects `get` from Kubernetes nodes
 
-> ⚠️ **NOTE:** At the moment, only AWS S3 API is supported for buckets. S3-compatible APIs (such as IBM Cloud's Object Storage) should also work.
+> ⚠️ **NOTE:** At the moment, only AWS S3 API is supported for buckets. S3-compatible APIs should also work.
 
 To access and write these objects Zenhub also requires CLI/API credentials (`access_key_id`/`access_key_secret` or similar) for a IAM user with at least read and write access.
 
@@ -901,7 +901,7 @@ To obtain `w3id_default_endpoint_url` and `w3id_issuer_url`, go to **Application
 
 - This authentication option allows users to sign in through Microsoft Entra ID
 - An Microsoft Entra ID tenant is required to use this form of authentication
-- It can be enabled by following instructions for `azure_ad_enabled` in the main `kustomization.yaml`
+- It can be enabled by following instructions for `entra_id_enabled` in the main `kustomization.yaml`
 
 To configure your Microsoft Entra ID Application for Zenhub, you will need to do the following:
 
@@ -925,18 +925,18 @@ Start by going to the Entra ID portal in Microsoft Azure. The URL for this will 
 
 There are three values that need to be obtained from your Microsoft Entra ID Application to enable Microsoft Entra ID authentication via your kustomization.yaml file:
 
-- `azure_ad_client_id`
-- `azure_ad_client_secret`
-- `azure_ad_tenant_id`
+- `entra_id_client_id`
+- `entra_id_client_secret`
+- `entra_id_tenant_id`
 
-To obtain `azure_ad_client_id` and `azure_ad_tenant_id`, go to **App registrations > All applications > Your application > Overview**
+To obtain `entra_id_client_id` and `entra_id_tenant_id`, go to **App registrations > All applications > Your application > Overview**
 
-- The value for `azure_ad_client_id` will be the value for `Application (client) ID` found on the page.
-- The value for `azure_ad_tenant_id` will be the value for `Directory (tenant) ID` found on the page.
+- The value for `entra_id_client_id` will be the value for `Application (client) ID` found on the page.
+- The value for `entra_id_tenant_id` will be the value for `Directory (tenant) ID` found on the page.
 
-To obtain `azure_ad_client_secret`, go to **App registrations > All applications > Your application > Certificates & secrets**
+To obtain `entra_id_client_secret`, go to **App registrations > All applications > Your application > Certificates & secrets**
 
-- The value for `azure_ad_client_secret` will be the value for `Value` found on the page. Click the copy button to copy the value to your clipboard.
+- The value for `entra_id_client_secret` will be the value for `Value` found on the page. Click the copy button to copy the value to your clipboard.
 
 > ⚠️ **NOTE:** The login option will say Azure AD instead of Microsoft Entra ID since that name change was recent and not yet reflected in the Zenhub UI.
 

--- a/k8s-cluster/base/devsite/apps_v1_deployment_devsite.yaml
+++ b/k8s-cluster/base/devsite/apps_v1_deployment_devsite.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.kubernetes.io/version: 4.2.1
+    app.kubernetes.io/version: 4.3.0
   generation: 1
   labels:
     app.kubernetes.io/component: devsite
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        app.kubernetes.io/version: 4.2.1
+        app.kubernetes.io/version: 4.3.0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: devsite

--- a/k8s-cluster/base/pgbouncer/apps_v1_deployment_pgbouncer.yaml
+++ b/k8s-cluster/base/pgbouncer/apps_v1_deployment_pgbouncer.yaml
@@ -32,7 +32,7 @@ spec:
           value: verify-full
         - name: SERVER_TLS_CA_FILE
           value: /var/ca-bundle/postgres/postgres-ca.pem
-        image: us.gcr.io/zenhub-public/pgbouncer:zhe-4.2.1
+        image: us.gcr.io/zenhub-public/pgbouncer:zhe-4.3.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-admin.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-admin.yaml
@@ -100,6 +100,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: APP_SERVICE
           valueFrom:
             fieldRef:
@@ -230,15 +234,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -353,10 +377,6 @@ spec:
               key: clickhouse_enabled
               name: raptor
               optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: AI_LABELS_ENDPOINT
           valueFrom:
             configMapKeyRef:
@@ -405,10 +425,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -430,11 +468,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-api.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-api.yaml
@@ -93,25 +93,25 @@ spec:
         - name: AUTHV2_AZURE_AD_ENABLED
           valueFrom:
             configMapKeyRef:
-              key: azure_ad_enabled
+              key: entra_id_enabled
               name: configuration
               optional: true
         - name: AUTHV2_AZURE_AD_CLIENT_ID
           valueFrom:
             configMapKeyRef:
-              key: azure_ad_client_id
+              key: entra_id_client_id
               name: configuration
               optional: true
         - name: AUTHV2_AZURE_AD_TENANT_ID
           valueFrom:
             configMapKeyRef:
-              key: azure_ad_tenant_id
+              key: entra_id_tenant_id
               name: configuration
               optional: true
         - name: AUTHV2_AZURE_AD_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              key: azure_ad_client_secret
+              key: entra_id_client_secret
               name: configuration
               optional: true
         - name: AUTHV2_LDAP_ENABLED
@@ -209,6 +209,10 @@ spec:
               key: ai_features_enabled
               name: configuration
               optional: true
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RAILS_MAX_THREADS
           valueFrom:
             configMapKeyRef:
@@ -219,6 +223,8 @@ spec:
             configMapKeyRef:
               key: web_concurrency
               name: raptor-api
+        - name: TOAD_APP_URL
+          value: $(POD_NAMESPACE)-toad-api
         - name: RUBYOPT
           value: -W0
         - name: HOST_IP
@@ -356,15 +362,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -474,10 +500,6 @@ spec:
               key: clickhouse_enabled
               name: raptor
               optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: AI_LABELS_ENDPOINT
           valueFrom:
             configMapKeyRef:
@@ -526,10 +548,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -551,11 +591,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:
@@ -731,8 +766,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 700m
-            memory: 2000Mi
+            cpu: 1200m
+            memory: 4000Mi
           requests:
-            cpu: 600m
-            memory: 1500Mi
+            cpu: 800m
+            memory: 3000Mi

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-cable.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-cable.yaml
@@ -74,16 +74,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: RAILS_MAX_THREADS
-          valueFrom:
-            configMapKeyRef:
-              key: rails_max_threads
-              name: raptor-api
         - name: WEB_CONCURRENCY
           valueFrom:
             configMapKeyRef:
               key: web_concurrency
-              name: raptor-api
+              name: raptor-cable
+        - name: RAILS_MAX_THREADS
+          valueFrom:
+            configMapKeyRef:
+              key: rails_max_threads
+              name: raptor-cable
         - name: ACTION_CABLE_WORKERS_POOL_SIZE
           valueFrom:
             configMapKeyRef:
@@ -221,15 +221,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -392,10 +412,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -417,11 +455,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:
@@ -602,8 +635,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 600m
+            cpu: 2000m
             memory: 6G
           requests:
-            cpu: 400m
+            cpu: 1250m
             memory: 3G

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-sidekiq-worker-default.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-sidekiq-worker-default.yaml
@@ -87,6 +87,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: APP_SERVICE
           valueFrom:
             fieldRef:
@@ -217,15 +221,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -340,10 +364,6 @@ spec:
               key: clickhouse_enabled
               name: raptor
               optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: AI_LABELS_ENDPOINT
           valueFrom:
             configMapKeyRef:
@@ -392,10 +412,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -417,11 +455,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:
@@ -589,8 +622,8 @@ spec:
         name: raptor-sidekiq-worker
         resources:
           limits:
-            cpu: 550m
+            cpu: 1200m
             memory: 1500Mi
           requests:
-            cpu: 550m
+            cpu: 800m
             memory: 1000Mi

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-sidekiq-worker.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-sidekiq-worker.yaml
@@ -91,6 +91,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: APP_SERVICE
           valueFrom:
             fieldRef:
@@ -221,15 +225,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -344,10 +368,6 @@ spec:
               key: clickhouse_enabled
               name: raptor
               optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: AI_LABELS_ENDPOINT
           valueFrom:
             configMapKeyRef:
@@ -396,10 +416,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -421,11 +459,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:
@@ -593,8 +626,8 @@ spec:
         name: raptor-sidekiq-worker
         resources:
           limits:
-            cpu: 550m
+            cpu: 1200m
             memory: 1500Mi
           requests:
-            cpu: 550m
+            cpu: 800m
             memory: 1000Mi

--- a/k8s-cluster/base/raptor/apps_v1_deployment_raptor-webhook.yaml
+++ b/k8s-cluster/base/raptor/apps_v1_deployment_raptor-webhook.yaml
@@ -83,6 +83,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: APP_SERVICE
           valueFrom:
             fieldRef:
@@ -213,15 +217,35 @@ spec:
             configMapKeyRef:
               key: hubspot_paid_user_form_guid
               name: raptor
+        - name: HUBSPOT_PMF_SURVEY_FORM_GUID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_pmf_survey_form_guid
+              name: raptor
         - name: HUBSPOT_ZORG_OBJECT_ID
           valueFrom:
             configMapKeyRef:
               key: hubspot_zorg_object_id
               name: raptor
-        - name: HUBSPOT_ZORG_MEMBER_ASSOCIATION_TYPE_ID
+        - name: HUBSPOT_UNLICENSED_MEMBER_ASSOCIATION_TYPE_ID
           valueFrom:
             configMapKeyRef:
-              key: hubspot_zorg_member_association_type_id
+              key: hubspot_unlicensed_member_association_type_id
+              name: raptor
+        - name: HUBSPOT_LICENSED_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_licensed_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_EXTERNAL_USER_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_external_user_association_type_id
+              name: raptor
+        - name: HUBSPOT_ADMIN_ASSOCIATION_TYPE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: hubspot_admin_association_type_id
               name: raptor
         - name: AUTH_ISSUER_URLS
           valueFrom:
@@ -336,10 +360,6 @@ spec:
               key: clickhouse_enabled
               name: raptor
               optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: AI_LABELS_ENDPOINT
           valueFrom:
             configMapKeyRef:
@@ -388,10 +408,28 @@ spec:
               key: azure_private_openai_endpoint_16k
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
         - name: AZURE_PRIVATE_OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               key: azure_private_openai_api_key
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
               name: raptor
               optional: true
         - name: SIDEKIQ_REDIS_URL
@@ -413,11 +451,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:

--- a/k8s-cluster/base/raptor/batch_v1_job_raptor-db-migrate.yaml
+++ b/k8s-cluster/base/raptor/batch_v1_job_raptor-db-migrate.yaml
@@ -238,6 +238,24 @@ spec:
               key: azure_private_openai_api_key
               name: raptor
               optional: true
+        - name: AZURE_PRIVATE_OPENAI_ENDPOINT_GPT4
+          valueFrom:
+            configMapKeyRef:
+              key: azure_private_openai_endpoint_gpt4
+              name: raptor
+              optional: true
+        - name: AZURE_PRIVATE_OPENAI_GPT4_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: azure_private_openai_gpt4_api_key
+              name: raptor
+              optional: true
+        - name: PROMETHEUS_EXPORTER_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: prometheus_exporter_host
+              name: raptor
+              optional: true
         - name: CLICKHOUSE_ENABLED
           valueFrom:
             configMapKeyRef:
@@ -268,11 +286,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: lockbox_master_key
-              name: internal
-        - name: GITHUB_TOKEN_VALUE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: github_token_value_key
               name: internal
         - name: GITHUB_WEBHOOKS_SECRET
           valueFrom:

--- a/k8s-cluster/base/raptor/configmaps.yaml
+++ b/k8s-cluster/base/raptor/configmaps.yaml
@@ -19,7 +19,9 @@ metadata:
 ---
 apiVersion: v1
 data:
-  action_cable_workers_pool_size: "2"
+  action_cable_workers_pool_size: "7"
+  rails_max_threads: "8"
+  web_concurrency: "4"
 kind: ConfigMap
 metadata:
   name: raptor-cable
@@ -84,10 +86,14 @@ data:
   github_html_url: $(github_hostname)
   github_webhook_enabled: "true"
   google_oauth2_client_id: ""
+  hubspot_admin_association_type_id: ""
+  hubspot_external_user_association_type_id: ""
+  hubspot_licensed_user_association_type_id: ""
   hubspot_paid_user_form_guid: ""
   hubspot_platform_signup_form_guid: ""
+  hubspot_pmf_survey_form_guid: ""
   hubspot_portal_id: ""
-  hubspot_zorg_member_association_type_id: ""
+  hubspot_unlicensed_member_association_type_id: ""
   hubspot_zorg_object_id: ""
   is_enterprise: "true"
   is_upload_file_to_local: "false"

--- a/k8s-cluster/base/toad/apps_v1_deployment_toad-api.yaml
+++ b/k8s-cluster/base/toad/apps_v1_deployment_toad-api.yaml
@@ -287,11 +287,6 @@ spec:
             secretKeyRef:
               key: internal_auth_token
               name: internal
-        - name: RAPTOR_SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              key: secret_key_base
-              name: internal
         - name: GITHUB_APP_SECRET
           valueFrom:
             secretKeyRef:
@@ -301,11 +296,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ghwebhook_invite_code
-              name: toad
-        - name: LAUNCHDARKLY_SDK_KEY
-          valueFrom:
-            secretKeyRef:
-              key: launchdarkly_sdk_key
               name: toad
         - name: SLACK_WEBHOOK
           valueFrom:
@@ -391,10 +381,10 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 450Mi
+            memory: 1000Mi
           requests:
-            cpu: 200m
-            memory: 410Mi
+            cpu: 300m
+            memory: 600Mi
       initContainers:
       - command:
         - sh

--- a/k8s-cluster/base/toad/apps_v1_deployment_toad-cron.yaml
+++ b/k8s-cluster/base/toad/apps_v1_deployment_toad-cron.yaml
@@ -270,11 +270,6 @@ spec:
             secretKeyRef:
               key: internal_auth_token
               name: internal
-        - name: RAPTOR_SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              key: secret_key_base
-              name: internal
         - name: GITHUB_APP_SECRET
           valueFrom:
             secretKeyRef:
@@ -284,11 +279,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ghwebhook_invite_code
-              name: toad
-        - name: LAUNCHDARKLY_SDK_KEY
-          valueFrom:
-            secretKeyRef:
-              key: launchdarkly_sdk_key
               name: toad
         - name: SLACK_WEBHOOK
           valueFrom:

--- a/k8s-cluster/base/toad/apps_v1_deployment_toad-websocket.yaml
+++ b/k8s-cluster/base/toad/apps_v1_deployment_toad-websocket.yaml
@@ -274,11 +274,6 @@ spec:
             secretKeyRef:
               key: internal_auth_token
               name: internal
-        - name: RAPTOR_SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              key: secret_key_base
-              name: internal
         - name: GITHUB_APP_SECRET
           valueFrom:
             secretKeyRef:
@@ -288,11 +283,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ghwebhook_invite_code
-              name: toad
-        - name: LAUNCHDARKLY_SDK_KEY
-          valueFrom:
-            secretKeyRef:
-              key: launchdarkly_sdk_key
               name: toad
         - name: SLACK_WEBHOOK
           valueFrom:

--- a/k8s-cluster/base/toad/apps_v1_deployment_toad-worker.yaml
+++ b/k8s-cluster/base/toad/apps_v1_deployment_toad-worker.yaml
@@ -270,11 +270,6 @@ spec:
             secretKeyRef:
               key: internal_auth_token
               name: internal
-        - name: RAPTOR_SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              key: secret_key_base
-              name: internal
         - name: GITHUB_APP_SECRET
           valueFrom:
             secretKeyRef:
@@ -284,11 +279,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ghwebhook_invite_code
-              name: toad
-        - name: LAUNCHDARKLY_SDK_KEY
-          valueFrom:
-            secretKeyRef:
-              key: launchdarkly_sdk_key
               name: toad
         - name: SLACK_WEBHOOK
           valueFrom:

--- a/k8s-cluster/configmap-generator.sh
+++ b/k8s-cluster/configmap-generator.sh
@@ -17,7 +17,7 @@ export `grep -hir "chrome_extension_webstore_url=" kustomization.yaml | awk '{pr
 export `grep -hir "graphiql_explorer_subdomain_prefix=" kustomization.yaml | awk '{print $2}'`
 export `grep -hir "email_pw_enabled=" kustomization.yaml | awk '{print $2}'`
 export `grep -hir "w3id_enabled=" kustomization.yaml | awk '{print $2}'`
-export `grep -hir "azure_ad_enabled=" kustomization.yaml | awk '{print $2}'`
+export `grep -hir "entra_id_enabled=" kustomization.yaml | awk '{print $2}'`
 export `grep -hir "ldap_enabled=" kustomization.yaml | awk '{print $2}'`
 export `grep -hir "saml_enabled=" kustomization.yaml | awk '{print $2}'`
 export `grep -hir "notion_enabled=" kustomization.yaml | awk '{print $2}'`
@@ -30,7 +30,7 @@ https_admin_zhe_hostname="https://$admin_zhe_hostname"
 cable_allowed_origins="$https_zhe_hostname, $github_hostname, null"
 auth_options_email_pw=$email_pw_enabled
 auth_options_w3id=$w3id_enabled
-auth_options_azure_ad=$azure_ad_enabled
+auth_options_entra_id=$entra_id_enabled
 auth_options_ldap=$ldap_enabled
 auth_options_saml=$saml_enabled
 feat_options_notion=$notion_enabled
@@ -75,7 +75,7 @@ sed_wrap "s/%%zhe_hostname%%/$zhe_hostname/g" base/kustomization.yaml
 
 # Replace W3ID value in base/kraken/configmaps.yaml
 sed_wrap "s/\"W3ID\": .*,/\"W3ID\": $auth_options_w3id,/g" base/kraken/configmaps.yaml
-sed_wrap "s/\"AzureAD\": .*,/\"AzureAD\": $auth_options_azure_ad,/g" base/kraken/configmaps.yaml
+sed_wrap "s/\"AzureAD\": .*,/\"AzureAD\": $auth_options_entra_id,/g" base/kraken/configmaps.yaml
 sed_wrap "s/\"LDAP\": .*,/\"LDAP\": $auth_options_ldap,/g" base/kraken/configmaps.yaml
 sed_wrap "s/\"SAML\": .*,/\"SAML\": $auth_options_saml,/g" base/kraken/configmaps.yaml
 # IMPORTANT: Zenhub auth is last in the list and does not contain a comma

--- a/k8s-cluster/deployment-checklist.txt
+++ b/k8s-cluster/deployment-checklist.txt
@@ -11,7 +11,7 @@
 - [ ] Configure an OAuth App in GitHub Enterprise Server
 
 #### Kubernetes Requirements
-- [ ] Obtain access to a Kubernetes cluster running K8s v1.27 or greater
+- [ ] Obtain access to a Kubernetes cluster running K8s v1.28 or greater
 - [ ] Install `kubectl` locally
 - [ ] Install `kustomize` v4.5.7 or greater locally
 - [ ] Create a dedicated namespace in the cluster for Zenhub

--- a/k8s-cluster/kustomization.yaml
+++ b/k8s-cluster/kustomization.yaml
@@ -32,32 +32,32 @@ commonLabels:
   app.kubernetes.io/managed-by: kustomize
 
 commonAnnotations:
-  app.kubernetes.io/version: 4.2.1
+  app.kubernetes.io/version: 4.3.0
 
 # [EDIT] If your cluster does not have access to our public Docker registry,
 # update the `newName` values with paths to your own private Docker registry.
 images:
   - name: kraken-webapp
     newName: us.gcr.io/zenhub-public/kraken-webapp
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: kraken-extension
     newName: us.gcr.io/zenhub-public/kraken-extension
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: kraken-zhe-admin
     newName: us.gcr.io/zenhub-public/kraken-zhe-admin
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: raptor-backend
     newName: us.gcr.io/zenhub-public/raptor-backend
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: toad-backend
     newName: us.gcr.io/zenhub-public/toad-backend
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: sanitycheck
     newName: us.gcr.io/zenhub-public/sanitycheck
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: devsite
     newName: us.gcr.io/zenhub-public/devsite
-    newTag: zhe-4.2.1
+    newTag: zhe-4.3.0
   - name: busybox
     newName: docker.io/library/busybox
     newTag: latest
@@ -141,11 +141,11 @@ configMapGenerator:
       # - w3id_default_endpoint_url=<your_default_endpoint> # e.g. https://acme.verify.ibm.com/v1.0/endpoint/default
       # - w3id_issuer_url=<your_issuer_url> # e.g. https://acme.verify.ibm.com/oidc/endpoint/default
 
-      # Azure AD authentication configuration
-      # [EDIT] (optional) Change azure_ad_enabled to true, then uncomment and fill out the rest of the options to enable
-      - azure_ad_enabled=false
-      # - azure_ad_client_id=<your_client_id> # e.g. 12345678-abcd-1234-abcd-1234567890ab
-      # - azure_ad_tenant_id=<your_tenant_id> # e.g. abcdefgh-4321-abcd-4321-abcdefgh1234
+      # Entra ID authentication configuration
+      # [EDIT] (optional) Change entra_id_enabled to true, then uncomment and fill out the rest of the options to enable
+      - entra_id_enabled=false
+      # - entra_id_client_id=<your_client_id> # e.g. 12345678-abcd-1234-abcd-1234567890ab
+      # - entra_id_tenant_id=<your_tenant_id> # e.g. abcdefgh-4321-abcd-4321-abcdefgh1234
 
       # LDAP authentication configuration
       # [EDIT] (optional) Change ldap_enabled to true, then uncomment and fill out the rest of the options to enable
@@ -208,8 +208,8 @@ secretGenerator:
       - admin_ui_pass=<some_pass>
       # [EDIT] (optional) Uncomment and fill to enable W3ID authentication
       # - w3id_client_secret=<your_client_secret> # e.g. U75zD5Zet4
-      # [EDIT] (optional) Uncomment and fill to enable Azure AD authentication
-      # - azure_ad_client_secret=<your_client_secret> # e.g. abcd12~efgh567ijkl890mnopq123rstu456vwxyz
+      # [EDIT] (optional) Uncomment and fill to enable Entra ID authentication
+      # - entra_id_client_secret=<your_client_secret> # e.g. abcd12~efgh567ijkl890mnopq123rstu456vwxyz
       # [EDIT] (optional) Uncomment and fill to enable LDAP authentication
       # - ldap_bind_password=<your_ldap_bind_password>
       # [EDIT] (optional) Uncomment and fill to enable Notion integration

--- a/k8s-cluster/support-bundle/support_bundle.sh
+++ b/k8s-cluster/support-bundle/support_bundle.sh
@@ -86,6 +86,12 @@ kubectl top nodes >> $overview_file
 echo "### Pods Not Running" >> $overview_file
 kubectl get pods --all-namespaces --field-selector=status.phase!=Running | grep -v Completed >> $overview_file
 
+# Get the journalctl logs from the VM for the current and previous boot
+journalctl_dir="$tempdir/journalctl"
+mkdir $journalctl_dir
+journalctl -b 0 > $journalctl_dir/boot-current.log
+journalctl -b -1 > $journalctl_dir/boot-previous.log
+
 echo "### Creating Tar archive"
 
 # Saves to /opt/zenhub/support-bundle/ on VM or the current directory on K8s

--- a/k8s-cluster/update/batch_v1_job_data_migration.yaml
+++ b/k8s-cluster/update/batch_v1_job_data_migration.yaml
@@ -389,7 +389,7 @@ spec:
                 secretKeyRef:
                   key: clickhouse_url
                   name: raptor
-          image: us.gcr.io/zenhub-public/raptor-backend:zhe-4.2.1
+          image: us.gcr.io/zenhub-public/raptor-backend:zhe-4.3.0
           imagePullPolicy: Always
           name: data-migration
           resources:

--- a/k8s-cluster/update/batch_v1_job_data_migration_previous.yaml
+++ b/k8s-cluster/update/batch_v1_job_data_migration_previous.yaml
@@ -389,7 +389,7 @@ spec:
                 secretKeyRef:
                   key: clickhouse_url
                   name: raptor
-          image: us.gcr.io/zenhub-public/raptor-backend:zhe-4.2.1
+          image: us.gcr.io/zenhub-public/raptor-backend:zhe-4.3.0
           imagePullPolicy: Always
           name: data-migration
           resources:


### PR DESCRIPTION
- security patches
- compatibility with ghe 3.13 3.14
- zhe vm upgrade support for minor version skip from 4.1 --> 4.3

(for context `cp -fR enterprise/public_repo/ ~/repos/zenhub-enterprise` from devops-kubernetes:zhe-4.3.0